### PR TITLE
Some fixes

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -180,7 +180,7 @@ class LUAParser {
 				}
 
 				// Start of table
-				if(isset($parts[1]) === true && ($parts[1] === '{' || empty($parts[1]) === true)) {
+				if(isset($parts[1]) === true && ($parts[1] === '{' || (empty($parts[1]) === true && $parts[1] != 0))) {
 
 					// When Bracket is in next line, skip the next line
 					$this->_pos += (empty($parts[1]) === true) ? 2 : 1;

--- a/parser.php
+++ b/parser.php
@@ -197,13 +197,19 @@ class LUAParser {
 
 				// Get value
 				else {
-
-					// Save key to avoid multiply function execution
-					$key = $this->getValue($parts[0], true);
-
 					// Data has been found
-					if(mb_strlen($key) > 0 && mb_strlen($parts[1]) > 0) {
-						$data[$key] = $this->getValue($parts[1], false);
+					if (isset($parts[1])) {
+						// There's a key, so save key to avoid multiply function execution
+						$key = $this->getValue($parts[0], true);
+
+						if(mb_strlen($key) > 0 && mb_strlen($parts[1]) > 0) {
+							$data[$key] = $this->getValue($parts[1], false);
+						}
+					} else {
+						// There isn't a key, so just add to the end of the array
+						if (mb_strlen($parts[0]) > 0) {
+							$data[] = $this->getValue($parts[0], false);
+						}
 					}
 
 					// Increase position

--- a/parser.php
+++ b/parser.php
@@ -195,6 +195,12 @@ class LUAParser {
 					$this->_pos++;
 				}
 
+				// { }, case
+				else if(isset($parts[1]) == true && $parts[1][0] == '{' &&  mb_strlen($parts[1]) > 1 && ($subpart = trim(substr($parts[1], 1))) && ($subpart == '},' || $subpart == '}')) {
+					$data[$this->getValue($parts[0], true)] = array();
+					$this->_pos++;
+				}
+
 				// Get value
 				else {
 					// Data has been found


### PR DESCRIPTION
Really usefull class!

I've found a couple issues while parsing a file, and tried to fix them.

Tested on PHP 7.1.9 / Windows 10

Example file:
```
tbl = {
	[1] = {
		title = "XQuery Kick Start",
		authors = {
			"James McGovern",
			"Per Bothner"
		},
		references = { },
		pages = 0
	},
	[2] = {
		title = "XQuery Kick Start 2",
		authors = {
			"James McGovern",
		},
		references = { },
		pages = 20
	},
}
```

First issue: the `authors` table (that doesn't have a key on the left) wasn't parsed corectly. (Maybe this is related to issue #2 ?)

Second issue: the line `references = { },` was returning a string `{ }` instead of an empty array

Third issue: `pages = 0` (without a comma) was creating a nested structure, because it was being considered empty (PHP `empty` function considers `0` as empty)